### PR TITLE
Update the webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
         path: path.resolve(__dirname, 'static/js')
     },
     module : {
-        loaders : [
+        rules : [
             {
                 test: /\.js/,
                 include: path.resolve(__dirname, 'frontend'),


### PR DESCRIPTION
The webpack.config.js used the outdated "loaders" configuration, which
has been renamed to "rules". More information about this change can be
found on their documentation: https://webpack.js.org/guides/migrating/.